### PR TITLE
Added workaround for http/https protocol usage

### DIFF
--- a/Piwik/README
+++ b/Piwik/README
@@ -1,5 +1,5 @@
-Version 1.0.12
-Plugin compatible with ILIAS 4.2.x to 4.4.x
+Version 1.0.13
+Plugin compatible with ILIAS 4.2.x to 5.2.x
 
 DESCRIPTION
 -----------

--- a/Piwik/lang/ilias_de.lang
+++ b/Piwik/lang/ilias_de.lang
@@ -7,3 +7,5 @@ piwik_url_http#:#Piwik URL HTTP
 piwik_url_http_info#:#Adresse zur Piwik Installation, (je nach Piwik Installation z.B. http://www.example.com/piwik/ oder http://piwik.example.com)
 piwik_url_https#:#Piwik URL HTTPs
 piwik_url_https_info#:#Adresse zur Piwik Installation wenn SSL genutzt werden soll
+piwik_host#:#Piwik URL
+piwik_host_info#:#Adresse zur Piwik Installation (i.e. http://piwik.meinserver.com/ or https://piwik.meinserver.com/)

--- a/Piwik/lang/ilias_en.lang
+++ b/Piwik/lang/ilias_en.lang
@@ -7,3 +7,5 @@ piwik_url_http#:#Piwik URL HTTP
 piwik_url_http_info#:#Address to your piwik installation, (for example: http://www.example.com/piwik/ or http://piwik.example.com)
 piwik_url_https#:#Piwik URL HTTPS
 piwik_url_https_info#:#Address to your piwik installation when using SSL
+piwik_host#:#Piwik URL
+piwik_host_info#:#Address to your piwik installation (i.e. http://piwik.myserver.com/ or https://piwik.myserver.com/)

--- a/Piwik/plugin.php
+++ b/Piwik/plugin.php
@@ -1,8 +1,8 @@
 <?php
 $id = "piwik";
-$version = "1.0.12";
+$version = "1.0.13";
 $ilias_min_version = "4.2.0";
-$ilias_max_version = "4.4.999";
+$ilias_max_version = "5.2.999";
 $responsible = "Peter Boden";
 $responsible_mail = "mail@pebosi.net";
 ?>

--- a/Piwik/templates/tpl.piwik_tracking.html
+++ b/Piwik/templates/tpl.piwik_tracking.html
@@ -3,7 +3,11 @@ var _paq = _paq || [];
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
 (function() {
-    var u="//{PIWIK_HOST}/";
+    var u = '';
+    if( "{PIWIK_HOST}".substr(0,4) != "http" ) {
+        u = document.location.protocol + '//';
+    }
+    u += "{PIWIK_HOST}/";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
     _paq.push(['setSiteId', {PIWIK_SITE_ID}]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
-Version 1.0.12
-Plugin compatible with ILIAS 4.2.x to 4.4.x
+Version 1.0.13
+Plugin compatible with ILIAS 4.2.x to 5.2.x
 
 DESCRIPTION
 -----------


### PR DESCRIPTION
v1.0.13
Tested with ILIAS 5.2.9 and piwik 3.2.0
Tested on HTTP and HTTPS
Features:
- User may now add the piwik_host with or without protocol
- If no protocol is given, the plugin uses the same as ilias
- The missing lang variables are added now